### PR TITLE
Add support for constant attributes

### DIFF
--- a/examples/examples/hyper.rs
+++ b/examples/examples/hyper.rs
@@ -24,7 +24,13 @@ async fn shutdown_signal() {
 
 #[tokio::main]
 async fn main() {
-    let logger = tracing_logstash::Layer::default();
+    let logger = tracing_logstash::Layer::default()
+        .event_format(tracing_logstash::logstash::LogstashFormat::default()
+            .with_constants(vec![
+                ("service.name", "tracing-logstash".to_owned()),
+                ("service.environment", "development".to_owned()),
+            ])
+        );
 
     let env_filter = EnvFilter::try_from_default_env()
         .or_else(|_| EnvFilter::try_new("info"))


### PR DESCRIPTION
This allow crate users to add their own constant attributes which are included in every log message.
Since tracing doesn't apparently provide such a feature, the recommendation is to implement it at the format_event level, so we might as well include it in these types of crates as a configuration feature.

https://github.com/tokio-rs/tracing/issues/1531