### PR TITLE
Default to using StdoutLock for writing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 
 members = [
     "examples",

--- a/tracing-logstash/src/lib.rs
+++ b/tracing-logstash/src/lib.rs
@@ -14,7 +14,7 @@ use tracing_subscriber::fmt::MakeWriter;
 use tracing_subscriber::layer::Context;
 use tracing_subscriber::registry::LookupSpan;
 
-pub struct Layer<S, E = LogstashFormat, W = fn() -> std::io::Stdout> {
+pub struct Layer<S, E = LogstashFormat, W = fn() -> std::io::StdoutLock<'static>> {
     record_separator: Vec<u8>,
     make_writer: W,
     event_format: E,
@@ -25,7 +25,7 @@ impl<S> Default for Layer<S> {
     fn default() -> Self {
         Self {
             record_separator: vec![b'\n'],
-            make_writer: std::io::stdout,
+            make_writer: || std::io::stdout().lock(),
             event_format: Default::default(),
             _inner: Default::default(),
         }


### PR DESCRIPTION
When running in a multi-threaded environment naively using `Stdio` could lead to parts of different log lines being interleaved, breaking the written JSON